### PR TITLE
Fix live log generator output ordering

### DIFF
--- a/web_ai_researcher.py
+++ b/web_ai_researcher.py
@@ -1025,7 +1025,13 @@ def create_ui():
                     f"<span class='status-indicator status-success'></span> {status}"
                 )
 
-            yield token_count, status_with_indicator, filtered_logs, scroll_script, updated_index
+            yield (
+                state,
+                status_with_indicator,
+                filtered_logs,
+                scroll_script,
+                updated_index,
+            )
             # yield token_count, status_with_indicator, logs2
         else:
             logs2, updated_index = get_latest_logs(500, state, LOG_QUEUE, last_index)


### PR DESCRIPTION
## Summary
- update the final yield from `process_with_live_logs` so it returns the state before other outputs
- ensure the generator consistently emits tuples compatible with the Gradio state object

## Testing
- python - <<'PY'
import types
import queue
import threading
import time
import web_ai_researcher

# Ensure global queue empty
web_ai_researcher.LOG_QUEUE = queue.Queue()
web_ai_researcher.LOG_FILE = None

# Patch run_ai_researcher to simulate quick response
call_log = {}

def fake_run_ai_researcher(question, reference, module_name):
    call_log['called'] = True
    time.sleep(0.2)
    return ('answer', '5', '✅ Success')

web_ai_researcher.run_ai_researcher = fake_run_ai_researcher

# Recreate nested function
code_consts = web_ai_researcher.create_ui.__code__.co_consts
proc_code = None
for const in code_consts:
    if isinstance(const, type(web_ai_researcher.create_ui.__code__)) and const.co_name == 'process_with_live_logs':
        proc_code = const
        break
process_with_live_logs = types.FunctionType(proc_code, web_ai_researcher.create_ui.__globals__)

# Run generator and collect outputs
outputs = []
for update in process_with_live_logs('q', 'ref', 'mod', [], 0):
    outputs.append(update)

print('updates count', len(outputs))
print('last update length', len(outputs[-1]))
print('last update first elem type', type(outputs[-1][0]))
print('last update contents', outputs[-1])
print('called run', call_log.get('called', False))
PY

------
https://chatgpt.com/codex/tasks/task_b_68d7d2a0044c8329bb92ebed7aebbbc0