### PR TITLE
Ensure logging uses absolute paths and restore cwd

### DIFF
--- a/main_ai_researcher.py
+++ b/main_ai_researcher.py
@@ -68,26 +68,30 @@ def main_ai_researcher(input, reference, mode):
                 current_file_path = os.path.realpath(__file__)
                 current_dir = os.path.dirname(current_file_path)
                 sub_dir = os.path.join(current_dir, "research_agent")
-                os.chdir(sub_dir)
+                original_cwd = os.getcwd()
+                try:
+                    os.chdir(sub_dir)
 
-                from research_agent.constant import COMPLETION_MODEL
-                from research_agent import run_infer_idea, run_infer_plan
+                    from research_agent.constant import COMPLETION_MODEL
+                    from research_agent import run_infer_idea, run_infer_plan
 
-                args = get_args_research()
-                # category="vq"
-                # instance_id="rotation_vq"
-                args.instance_path = f"../benchmark/final/{category}/{instance_id}.json"
-                args.task_level = task_level
-                args.model = COMPLETION_MODEL
-                args.container_name = container_name
-                args.workplace_name = workplace_name
-                args.cache_path = cache_path
-                args.port = port
-                args.max_iter_times = max_iter_times
-                args.category = category
+                    args = get_args_research()
+                    # category="vq"
+                    # instance_id="rotation_vq"
+                    args.instance_path = f"../benchmark/final/{category}/{instance_id}.json"
+                    args.task_level = task_level
+                    args.model = COMPLETION_MODEL
+                    args.container_name = container_name
+                    args.workplace_name = workplace_name
+                    args.cache_path = cache_path
+                    args.port = port
+                    args.max_iter_times = max_iter_times
+                    args.category = category
 
-                run_infer_plan.main(args, input, reference)
-                global_state.INIT_FLAG = False
+                    run_infer_plan.main(args, input, reference)
+                finally:
+                    os.chdir(original_cwd)
+                    global_state.INIT_FLAG = False
         case 'Reference-Based Ideation':
             # clear_screen()
             if global_state.INIT_FLAG is False:
@@ -95,36 +99,40 @@ def main_ai_researcher(input, reference, mode):
                 current_file_path = os.path.realpath(__file__)
                 current_dir = os.path.dirname(current_file_path)
                 sub_dir = os.path.join(current_dir, "research_agent")
-                os.chdir(sub_dir)
+                original_cwd = os.getcwd()
+                try:
+                    os.chdir(sub_dir)
 
-                from research_agent.constant import COMPLETION_MODEL
-                from research_agent import run_infer_idea, run_infer_plan
-                from research_agent.constant import COMPLETION_MODEL
-                args = get_args_research()
-                # category="vq"
-                # instance_id="one_layer_vq"
-                # args.instance_path = f"../benchmark/final/{category}/{instance_id}.json"
-                # args.container_name = "paper_eval"
-                # args.task_level = "task1"
-                # args.model = COMPLETION_MODEL
-                # args.workplace_name = "workplace"
-                # args.cache_path = "cache"
-                # args.port = 12356
-                # args.max_iter_times = 0
+                    from research_agent.constant import COMPLETION_MODEL
+                    from research_agent import run_infer_idea, run_infer_plan
+                    from research_agent.constant import COMPLETION_MODEL
+                    args = get_args_research()
+                    # category="vq"
+                    # instance_id="one_layer_vq"
+                    # args.instance_path = f"../benchmark/final/{category}/{instance_id}.json"
+                    # args.container_name = "paper_eval"
+                    # args.task_level = "task1"
+                    # args.model = COMPLETION_MODEL
+                    # args.workplace_name = "workplace"
+                    # args.cache_path = "cache"
+                    # args.port = 12356
+                    # args.max_iter_times = 0
 
 
-                args.instance_path = f"../benchmark/final/{category}/{instance_id}.json"
-                args.container_name = container_name
-                args.task_level = task_level
-                args.model = COMPLETION_MODEL
-                args.workplace_name = workplace_name
-                args.cache_path = cache_path
-                args.port = port
-                args.max_iter_times = max_iter_times
-                args.category = category
+                    args.instance_path = f"../benchmark/final/{category}/{instance_id}.json"
+                    args.container_name = container_name
+                    args.task_level = task_level
+                    args.model = COMPLETION_MODEL
+                    args.workplace_name = workplace_name
+                    args.cache_path = cache_path
+                    args.port = port
+                    args.max_iter_times = max_iter_times
+                    args.category = category
 
-                run_infer_idea.main(args, reference)
-                global_state.INIT_FLAG = False
+                    run_infer_idea.main(args, reference)
+                finally:
+                    os.chdir(original_cwd)
+                    global_state.INIT_FLAG = False
         case 'Paper Generation Agent':
             # clear_screen()
             if global_state.INIT_FLAG is False:

--- a/web_ai_researcher.py
+++ b/web_ai_researcher.py
@@ -36,7 +36,8 @@ def setup_path():
 
 # 配置日志系统
 def setup_logging():
-    logs_dir = os.path.join(os.path.dirname(__file__), "logs")
+    base_dir = os.path.abspath(os.path.dirname(__file__))
+    logs_dir = os.path.join(base_dir, "logs")
     os.makedirs(logs_dir, exist_ok=True)
     current_date = datetime.datetime.now().strftime("%Y-%m-%d %H-%M-%S")
     log_file = os.path.join(logs_dir, f"log_{current_date}.log")


### PR DESCRIPTION
## Summary
- make the web logging directory resolve from an absolute base path so file handlers and global state use consistent locations
- wrap research agent runs with cwd preservation so later logging still resolves against the project root

## Testing
- python - <<'PY'
import logging
import web_ai_researcher

log_file = web_ai_researcher.setup_logging()
logging.info('--- Conversation Start ---')
logging.info('User: Hello agent!')
logging.info('Assistant: Greetings!')
print(log_file)
PY

------
https://chatgpt.com/codex/tasks/task_b_68d7dddf59f08329be90778dba474dd0