### PR TITLE
Track token usage across researcher runs

### DIFF
--- a/global_state.py
+++ b/global_state.py
@@ -20,4 +20,22 @@ INIT_FLAG = False
 # port = 12345
 # test_pull_name = 'autoagent_mirror'
 # git_clone = True
+PROMPT_TOKENS = 0
+COMPLETION_TOKENS = 0
+
+
+def reset_token_usage() -> None:
+    """Reset the global counters that track LLM token consumption."""
+    global PROMPT_TOKENS, COMPLETION_TOKENS
+    PROMPT_TOKENS = 0
+    COMPLETION_TOKENS = 0
+
+
+def get_token_usage() -> dict:
+    """Return the aggregated token usage recorded so far."""
+    return {
+        "prompt_token_count": PROMPT_TOKENS,
+        "completion_token_count": COMPLETION_TOKENS,
+    }
+
 # local_env = False

--- a/main_ai_researcher.py
+++ b/main_ai_researcher.py
@@ -35,11 +35,13 @@ def get_args_paper():
 def main_ai_researcher(input, reference, mode):
     # if main_autoagent.mode is None:
     #     main_autoagent.mode = mode
-        
+
     # if main_autoagent.mode != mode:
     #     model = COMPLETION_MODEL
     #     main_autoagent.mode = mode
     #     global_state.INIT_FLAG = False
+    global_state.reset_token_usage()
+    answer = ""
     load_dotenv()
     category = os.getenv("CATEGORY")
     instance_id = os.getenv("INSTANCE_ID")
@@ -86,7 +88,9 @@ def main_ai_researcher(input, reference, mode):
                 args.max_iter_times = max_iter_times
                 args.category = category
 
-                run_infer_plan.main(args, input, reference)
+                result = run_infer_plan.main(args, input, reference)
+                if result is not None:
+                    answer = result
                 global_state.INIT_FLAG = False
         case 'Reference-Based Ideation':
             # clear_screen()
@@ -123,7 +127,9 @@ def main_ai_researcher(input, reference, mode):
                 args.max_iter_times = max_iter_times
                 args.category = category
 
-                run_infer_idea.main(args, reference)
+                result = run_infer_idea.main(args, reference)
+                if result is not None:
+                    answer = result
                 global_state.INIT_FLAG = False
         case 'Paper Generation Agent':
             # clear_screen()
@@ -138,5 +144,9 @@ def main_ai_researcher(input, reference, mode):
                 args.research_field = research_field
                 args.instance_id = instance_id
 
-                asyncio.run(writing.writing(args.research_field, args.instance_id))
+                writing_result = asyncio.run(writing.writing(args.research_field, args.instance_id))
+                if writing_result is not None:
+                    answer = writing_result
                 global_state.INIT_FLAG = False
+    token_usage = global_state.get_token_usage()
+    return answer, token_usage

--- a/research_agent/inno/core.py
+++ b/research_agent/inno/core.py
@@ -7,6 +7,7 @@ from datetime import datetime
 # Local imports
 import litellm
 from litellm import ContextWindowExceededError, BadRequestError
+import global_state
 from litellm.types.utils import Message as litellmMessage
 from .util import function_to_json, debug_print, merge_chunk, pretty_print_messages
 from .types import (
@@ -79,6 +80,32 @@ def should_retry_error(retry_state: RetryCallState):
     ])
 __CTX_VARS_NAME__ = "context_variables"
 logger = LoggerManager.get_logger()
+
+
+def _get_usage_value(usage_obj, key: str) -> int:
+    if usage_obj is None:
+        return 0
+    if hasattr(usage_obj, key):
+        value = getattr(usage_obj, key)
+        return value or 0
+    if isinstance(usage_obj, dict):
+        value = usage_obj.get(key, 0)
+        return value or 0
+    return 0
+
+
+def _accumulate_token_usage(response) -> None:
+    usage = getattr(response, "usage", None)
+    if not usage:
+        return
+
+    prompt_tokens = _get_usage_value(usage, "prompt_tokens")
+    completion_tokens = _get_usage_value(usage, "completion_tokens")
+
+    global_state.PROMPT_TOKENS += prompt_tokens
+    global_state.COMPLETION_TOKENS += completion_tokens
+
+
 def truncate_message(message: str) -> str:
     """按比例截断消息"""
     if not message:
@@ -156,7 +183,9 @@ class MetaChain:
         if tools and create_params['model'].startswith("gpt"):
             create_params["parallel_tool_calls"] = agent.parallel_tool_calls
 
-        return completion(**create_params)
+        response = completion(**create_params)
+        _accumulate_token_usage(response)
+        return response
 
     def handle_function_result(self, result, debug) -> Result:
         match result:
@@ -398,6 +427,7 @@ class MetaChain:
             if tools and create_params['model'].startswith("gpt"):
                 create_params["parallel_tool_calls"] = agent.parallel_tool_calls
             completion_response = await acompletion(**create_params)
+            _accumulate_token_usage(completion_response)
         elif create_model in NOT_USE_FN_CALL:
             assert agent.tool_choice == "required", f"Non-function calling mode MUST use tool_choice = 'required' rather than {agent.tool_choice}"
             last_content = messages[-1]["content"]
@@ -427,6 +457,7 @@ class MetaChain:
                 "base_url": API_BASE_URL,
             }
             completion_response = await acompletion(**create_params)
+            _accumulate_token_usage(completion_response)
             last_message = [{"role": "assistant", "content": completion_response.choices[0].message.content}]
             converted_message = convert_non_fncall_messages_to_fncall_messages(last_message, tools)
             converted_tool_calls = [ChatCompletionMessageToolCall(**tool_call) for tool_call in converted_message[0]["tool_calls"]]

--- a/web_ai_researcher.py
+++ b/web_ai_researcher.py
@@ -539,7 +539,9 @@ def run_ai_researcher(question: str, reference: str, example_module: str) -> Tup
         try:
             # logging.info("Runing AI Researcher...")
             # answer, chat_history, token_info = run_society(society)
-            answer = main_ai_researcher(question, reference, example_module)
+            answer, token_info = main_ai_researcher(question, reference, example_module)
+            if answer is None:
+                answer = ""
             logging.info("Sucessully Runing AI Researcher")
         except Exception as e:
             logging.error(f"Error occurred while running Researcher: {str(e)}")
@@ -549,7 +551,6 @@ def run_ai_researcher(question: str, reference: str, example_module: str) -> Tup
                 f"❌ Error: Run failed - {str(e)}",
             )
 
-        token_info = None
         if not isinstance(token_info, dict):
             token_info = {}
 


### PR DESCRIPTION
## Summary
- add global counters for prompt and completion token usage with helpers to reset and read them
- accumulate token usage data after each synchronous and async completion call in the MetaChain core
- propagate aggregated token usage back through `main_ai_researcher` so the web UI shows real token consumption

## Testing
- python -m compileall global_state.py main_ai_researcher.py research_agent/inno/core.py web_ai_researcher.py

------
https://chatgpt.com/codex/tasks/task_b_68d7dddfb344832985548120048880b5